### PR TITLE
Issue #164 Detect progressive JPEG files

### DIFF
--- a/src/Unicorn.Tests.Integration/Images/Jpeg/JpegDataSegmentFactoryIntegrationTests.cs
+++ b/src/Unicorn.Tests.Integration/Images/Jpeg/JpegDataSegmentFactoryIntegrationTests.cs
@@ -99,7 +99,7 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
         [TestMethod]
         public async Task JpegDataSegmentFactoryClass_CreateSegmentAsyncMethod_ReturnsStartOfFrameSegmentWithCorrectEncodingMode_ForTestImage03()
         {
-            using FileStream sourceDataStream = new(_sourceImage01Path, FileMode.Open, FileAccess.Read);
+            using FileStream sourceDataStream = new(_sourceImage03Path, FileMode.Open, FileAccess.Read);
 
             JpegDataSegment testOutput = await JpegDataSegmentFactory.CreateSegmentAsync(sourceDataStream,
                 _sourceImage03StartOfFrameSegmentOffset, _sourceImage03StartOfFrameSegmentMarkerByte).ConfigureAwait(false);

--- a/src/Unicorn.Tests.Integration/Images/Jpeg/JpegDataSegmentFactoryIntegrationTests.cs
+++ b/src/Unicorn.Tests.Integration/Images/Jpeg/JpegDataSegmentFactoryIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
     public class JpegDataSegmentFactoryIntegrationTests
     {
         private readonly string _sourceImage01Path = Path.Combine("TestData", "exampleJpegImage01.jpg");
+        private readonly string _sourceImage03Path = Path.Combine("TestData", "exampleJpegImage03.jpg");
 
         private const int _sourceImage01StartOfFrameSegmentOffset = 0x3a4f;
         private const int _sourceImage01StartOfFrameSegmentMarkerByte = 0xc2;
@@ -20,6 +21,9 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
         // but it is not an Exif segment and must not be detected as such.
         private const int _sourceImage01UnknownSegmentOffset = 0x2a9c;
         private const int _sourceImage01UnknownSegmentMarkerByte = 0xe1;
+
+        private const int _sourceImage03StartOfFrameSegmentOffset = 0x9530;
+        private const int _sourceImage03StartOfFrameSegmentMarkerByte = 0xc0;
 
         private const int _exifSegmentMarkerByte = 0xe1;
         private const int _jfifSegmentMarkerByte = 0xe0;
@@ -39,6 +43,20 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
             StartOfFrameSegment segment = (StartOfFrameSegment)testOutput;
             Assert.IsTrue(segment.DotWidth != 0);
             Assert.IsTrue(segment.DotHeight != 0);
+        }
+
+        [TestMethod]
+        public async Task JpegDataSegmentFactoryClass_CreateSegmentAsyncMethod_ReturnsStartOfFrameSegmentWithCorrectEncodingMode_ForTestImage01()
+        {
+            using FileStream sourceDataStream = new(_sourceImage01Path, FileMode.Open, FileAccess.Read);
+
+            JpegDataSegment testOutput = await JpegDataSegmentFactory.CreateSegmentAsync(sourceDataStream,
+                _sourceImage01StartOfFrameSegmentOffset, _sourceImage01StartOfFrameSegmentMarkerByte).ConfigureAwait(false);
+
+            Assert.IsNotNull(testOutput);
+            Assert.IsInstanceOfType(testOutput, typeof(StartOfFrameSegment));
+            StartOfFrameSegment segment = (StartOfFrameSegment)testOutput;
+            Assert.AreEqual(JpegEncodingMode.Progressive, segment.EncodingMode);
         }
 
         [TestMethod]
@@ -76,6 +94,20 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
 
             Assert.IsNotNull(testOutput);
             Assert.AreEqual(JpegDataSegmentType.Unknown, testOutput.SegmentType);
+        }
+
+        [TestMethod]
+        public async Task JpegDataSegmentFactoryClass_CreateSegmentAsyncMethod_ReturnsStartOfFrameSegmentWithCorrectEncodingMode_ForTestImage03()
+        {
+            using FileStream sourceDataStream = new(_sourceImage01Path, FileMode.Open, FileAccess.Read);
+
+            JpegDataSegment testOutput = await JpegDataSegmentFactory.CreateSegmentAsync(sourceDataStream,
+                _sourceImage03StartOfFrameSegmentOffset, _sourceImage03StartOfFrameSegmentMarkerByte).ConfigureAwait(false);
+
+            Assert.IsNotNull(testOutput);
+            Assert.IsInstanceOfType(testOutput, typeof(StartOfFrameSegment));
+            StartOfFrameSegment segment = (StartOfFrameSegment)testOutput;
+            Assert.AreEqual(JpegEncodingMode.Sequential, segment.EncodingMode);
         }
 
 #pragma warning restore CA1707 // Identifiers should not contain underscores

--- a/src/Unicorn.Tests.Integration/Images/Jpeg/StartOfFrameSegmentIntegrationTests.cs
+++ b/src/Unicorn.Tests.Integration/Images/Jpeg/StartOfFrameSegmentIntegrationTests.cs
@@ -30,7 +30,7 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
         public async Task StartOfFrameSegmentClass_PopulateSegmentAsyncMethod_SetsDotWidthPropertyToCorrectValue_IfTestFileIsExampleJpegImage01()
         {
             using FileStream sourceDataStream = new(_sourceImage01Path, FileMode.Open, FileAccess.Read);
-            StartOfFrameSegment testObject = new(_sourceImage01StartOfFrameOffset, _sourceImage01SegmentLength);
+            StartOfFrameSegment testObject = new(_sourceImage01StartOfFrameOffset, _sourceImage01SegmentLength, JpegEncodingMode.Sequential);
 
             await testObject.PopulateSegmentAsync(sourceDataStream).ConfigureAwait(false);
 
@@ -41,7 +41,7 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
         public async Task StartOfFrameSegmentClass_PopulateSegmentAsyncMethod_SetsDotHeightPropertyToCorrectValue_IfTestFileIsExampleJpegImage01()
         {
             using FileStream sourceDataStream = new(_sourceImage01Path, FileMode.Open, FileAccess.Read);
-            StartOfFrameSegment testObject = new(_sourceImage01StartOfFrameOffset, _sourceImage01SegmentLength);
+            StartOfFrameSegment testObject = new(_sourceImage01StartOfFrameOffset, _sourceImage01SegmentLength, JpegEncodingMode.Sequential);
 
             await testObject.PopulateSegmentAsync(sourceDataStream).ConfigureAwait(false);
 
@@ -52,7 +52,7 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
         public async Task StartOfFrameSegmentClass_PopulateSegmentAsyncMethod_SetsDotWidthPropertyToCorrectValue_IfTestFileIsExampleJpegImage03()
         {
             using FileStream sourceDataStream = new(_sourceImage03Path, FileMode.Open, FileAccess.Read);
-            StartOfFrameSegment testObject = new(_sourceImage03StartOfFrameOffset, _sourceImage03SegmentLength);
+            StartOfFrameSegment testObject = new(_sourceImage03StartOfFrameOffset, _sourceImage03SegmentLength, JpegEncodingMode.Sequential);
 
             await testObject.PopulateSegmentAsync(sourceDataStream).ConfigureAwait(false);
 
@@ -63,7 +63,7 @@ namespace Unicorn.Tests.Integration.Images.Jpeg
         public async Task StartOfFrameSegmentClass_PopulateSegmentAsyncMethod_SetsDotHeightPropertyToCorrectValue_IfTestFileIsExampleJpegImage03()
         {
             using FileStream sourceDataStream = new(_sourceImage03Path, FileMode.Open, FileAccess.Read);
-            StartOfFrameSegment testObject = new(_sourceImage03StartOfFrameOffset, _sourceImage03SegmentLength);
+            StartOfFrameSegment testObject = new(_sourceImage03StartOfFrameOffset, _sourceImage03SegmentLength, JpegEncodingMode.Sequential);
 
             await testObject.PopulateSegmentAsync(sourceDataStream).ConfigureAwait(false);
 

--- a/src/Unicorn.Tests.Unit/Images/Jpeg/StartOfFrameSegmentUnitTests.cs
+++ b/src/Unicorn.Tests.Unit/Images/Jpeg/StartOfFrameSegmentUnitTests.cs
@@ -3,6 +3,7 @@ using System;
 using Tests.Utility.Extensions;
 using Tests.Utility.Providers;
 using Unicorn.Images.Jpeg;
+using Unicorn.Tests.Unit.TestHelpers;
 
 namespace Unicorn.Tests.Unit.Images.Jpeg
 {
@@ -19,8 +20,9 @@ namespace Unicorn.Tests.Unit.Images.Jpeg
         {
             long testParam0 = _rnd.NextLong();
             int testParam1 = _rnd.Next();
+            JpegEncodingMode testParam2 = _rnd.NextJpegEncodingMode();
 
-            StartOfFrameSegment testOutput = new(testParam0, testParam1);
+            StartOfFrameSegment testOutput = new(testParam0, testParam1, testParam2);
 
             Assert.AreEqual(testParam0, testOutput.StartOffset);
         }
@@ -30,10 +32,23 @@ namespace Unicorn.Tests.Unit.Images.Jpeg
         {
             long testParam0 = _rnd.NextLong();
             int testParam1 = _rnd.Next();
+            JpegEncodingMode testParam2 = _rnd.NextJpegEncodingMode();
 
-            StartOfFrameSegment testOutput = new(testParam0, testParam1);
+            StartOfFrameSegment testOutput = new(testParam0, testParam1, testParam2);
 
             Assert.AreEqual(testParam1, testOutput.Length);
+        }
+        
+        [TestMethod]
+        public void StartOfFrameSegmentClass_Constructor_SetsEncodingModehPropertyToValueOfThirdParameter()
+        {
+            long testParam0 = _rnd.NextLong();
+            int testParam1 = _rnd.Next();
+            JpegEncodingMode testParam2 = _rnd.NextJpegEncodingMode();
+
+            StartOfFrameSegment testOutput = new(testParam0, testParam1, testParam2);
+
+            Assert.AreEqual(testParam2, testOutput.EncodingMode);
         }
 
         [TestMethod]
@@ -41,8 +56,9 @@ namespace Unicorn.Tests.Unit.Images.Jpeg
         {
             long testParam0 = _rnd.NextLong();
             int testParam1 = _rnd.Next();
+            JpegEncodingMode testParam2 = _rnd.NextJpegEncodingMode();
 
-            StartOfFrameSegment testOutput = new(testParam0, testParam1);
+            StartOfFrameSegment testOutput = new(testParam0, testParam1, testParam2);
 
             Assert.AreEqual(JpegDataSegmentType.StartOfFrame, testOutput.SegmentType);
         }

--- a/src/Unicorn.Tests.Unit/TestHelpers/RandomExtensions.cs
+++ b/src/Unicorn.Tests.Unit/TestHelpers/RandomExtensions.cs
@@ -152,6 +152,12 @@ namespace Unicorn.Tests.Unit.TestHelpers
             JpegDataSegmentType.Exif,
         };
 
+        private static readonly JpegEncodingMode[] _validJpegEncodingMode = new[]
+        {
+            JpegEncodingMode.Sequential,
+            JpegEncodingMode.Progressive,
+        };
+
 #pragma warning disable CA5394 // Do not use insecure randomness
 
         internal static TableRuleStyle NextTableRuleStyle(this Random rnd) 
@@ -162,6 +168,9 @@ namespace Unicorn.Tests.Unit.TestHelpers
 
         internal static JpegDataSegmentType NextJpegDataSegmentType(this Random rnd)
             => rnd is null ? throw new ArgumentNullException(nameof(rnd)) : rnd.FromSet(_validJpegDataSegmentTypes);
+
+        internal static JpegEncodingMode NextJpegEncodingMode(this Random rnd)
+            => rnd is null ? throw new ArgumentNullException(nameof(rnd)) : rnd.FromSet(_validJpegEncodingMode);
 
         internal static FixedSizeTableCell NextFixedSizeTableCell(this Random rnd)
             => rnd is null ? throw new ArgumentNullException(nameof(rnd)) : new FixedSizeTableCell(rnd.NextDouble() * 100, rnd.NextDouble() * 100);

--- a/src/Unicorn/Images/Jpeg/JpegDataSegmentFactory.cs
+++ b/src/Unicorn/Images/Jpeg/JpegDataSegmentFactory.cs
@@ -11,6 +11,9 @@ namespace Unicorn.Images.Jpeg
         // Marker values for different types of JPEG "Start of frame" segments.
         private static readonly int[] START_OF_FRAME_MARKERS = { 0xc0, 0xc1, 0xc2, 0xc3, 0xc5, 0xc6, 0xc7, 0xc8, 0xc9, 0xca, 0xcb, 0xcd, 0xce, 0xcf };
 
+        // Which of the above indicate a progressively-encoded file.
+        private static readonly int[] PROGRESSIVE_START_OF_FRAME_MARKERS = { 0xc2, 0xc6, 0xca, 0xce };
+
         // Marker value and identification string for JFIF segments.  The marker value is the JPEG APP0 marker; the identification string is "JFIF" followed by a NUL byte.
         private const int JFIF_MARKER = 0xe0;
         private static readonly byte[] JFIF_IDENTIFICATION_STRING = { 0x4a, 0x46, 0x49, 0x46, 0 };
@@ -78,7 +81,7 @@ namespace Unicorn.Images.Jpeg
 
         private static JpegEncodingMode GetEncodingMode(int markerTypeByte)
         {
-            if (markerTypeByte == 0xc2 || markerTypeByte == 0xc6 || markerTypeByte == 0xca || markerTypeByte == 0xce)
+            if (PROGRESSIVE_START_OF_FRAME_MARKERS.Contains(markerTypeByte))
             {
                 return JpegEncodingMode.Progressive;
             }

--- a/src/Unicorn/Images/Jpeg/JpegDataSegmentFactory.cs
+++ b/src/Unicorn/Images/Jpeg/JpegDataSegmentFactory.cs
@@ -28,7 +28,8 @@ namespace Unicorn.Images.Jpeg
             int length = buffer.ReadBigEndianUShort() + 2;
             if (IsStartOfFrameMarker(markerTypeByte))
             {
-                return await BuildPopulatableSegment(dataStream, () => new StartOfFrameSegment(startOffset, length)).ConfigureAwait(false);
+                return await BuildPopulatableSegment(dataStream, () => new StartOfFrameSegment(startOffset, length, GetEncodingMode(markerTypeByte)))
+                    .ConfigureAwait(false);
             }
             if (await IsJfifSegmentAsync(dataStream, startOffset, markerTypeByte).ConfigureAwait(false))
             {
@@ -73,6 +74,15 @@ namespace Unicorn.Images.Jpeg
                 }
             }
             return true;
+        }
+
+        private static JpegEncodingMode GetEncodingMode(int markerTypeByte)
+        {
+            if (markerTypeByte == 0xc2 || markerTypeByte == 0xc6 || markerTypeByte == 0xca || markerTypeByte == 0xce)
+            {
+                return JpegEncodingMode.Progressive;
+            }
+            return JpegEncodingMode.Sequential;
         }
     }
 }

--- a/src/Unicorn/Images/Jpeg/JpegEncodingMode.cs
+++ b/src/Unicorn/Images/Jpeg/JpegEncodingMode.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Unicorn.Images.Jpeg
+{
+    public enum JpegEncodingMode
+    {
+        Sequential,
+        Progressive
+    }
+}

--- a/src/Unicorn/Images/Jpeg/JpegEncodingMode.cs
+++ b/src/Unicorn/Images/Jpeg/JpegEncodingMode.cs
@@ -1,12 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace Unicorn.Images.Jpeg
+﻿namespace Unicorn.Images.Jpeg
 {
+    /// <summary>
+    /// The encoding mode of a JPEG, in terms of sequential or progressive encoding.
+    /// </summary>
     public enum JpegEncodingMode
     {
+        /// <summary>
+        /// One of the sequential encoding modes.
+        /// </summary>
         Sequential,
+
+        /// <summary>
+        /// One of the progressive encoding modes.
+        /// </summary>
         Progressive
     }
 }

--- a/src/Unicorn/Images/Jpeg/StartOfFrameSegment.cs
+++ b/src/Unicorn/Images/Jpeg/StartOfFrameSegment.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Text;
+﻿using System.IO;
 using System.Threading.Tasks;
 using Unicorn.Base.Helpers.Extensions;
 using Unicorn.Exceptions;
@@ -14,7 +11,12 @@ namespace Unicorn.Images.Jpeg
 
         internal int DotHeight { get; private set; }
 
-        internal StartOfFrameSegment(long startOffset, int length) : base(startOffset, length, JpegDataSegmentType.StartOfFrame) { }
+        internal JpegEncodingMode EncodingMode { get; private set; }
+
+        internal StartOfFrameSegment(long startOffset, int length, JpegEncodingMode encodingMode) : base(startOffset, length, JpegDataSegmentType.StartOfFrame) 
+        {
+            EncodingMode = encodingMode;
+        }
 
         internal override async Task PopulateSegmentAsync(Stream dataStream)
         {

--- a/src/Unicorn/Images/JpegSourceImage.cs
+++ b/src/Unicorn/Images/JpegSourceImage.cs
@@ -36,6 +36,9 @@ namespace Unicorn.Images
         /// </summary>
         public override double AspectRatio => (DotWidth / HorizontalDotsPerPoint) / ((double) DotHeight / VerticalDotsPerPoint);
 
+        /// <summary>
+        /// The encoding mode of the JPEG (sequential or progressive).
+        /// </summary>
         public JpegEncodingMode EncodingMode => StartOfFrameSegment?.EncodingMode ?? JpegEncodingMode.Sequential;
 
         /// <summary>

--- a/src/Unicorn/Images/JpegSourceImage.cs
+++ b/src/Unicorn/Images/JpegSourceImage.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Unicorn.Exceptions;
-using Unicorn.Helpers;
 using Unicorn.Images.Jpeg;
 
 namespace Unicorn.Images
@@ -36,6 +35,8 @@ namespace Unicorn.Images
         /// The image aspect ratio, as a width-over-height fraction.
         /// </summary>
         public override double AspectRatio => (DotWidth / HorizontalDotsPerPoint) / ((double) DotHeight / VerticalDotsPerPoint);
+
+        public JpegEncodingMode EncodingMode => StartOfFrameSegment?.EncodingMode ?? JpegEncodingMode.Sequential;
 
         /// <summary>
         /// Load a JPEG image from a stream.  The stream's current position should be the first byte of the JPEG data

--- a/src/Unicorn/Writer/Streams/PdfJpegImageStream.cs
+++ b/src/Unicorn/Writer/Streams/PdfJpegImageStream.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Unicorn.Helpers;
 using Unicorn.Images;
+using Unicorn.Images.Jpeg;
 using Unicorn.Writer.Filters;
 using Unicorn.Writer.Interfaces;
 using Unicorn.Writer.Primitives;
@@ -24,7 +24,8 @@ namespace Unicorn.Writer.Streams
         /// <param name="objectId">The ID of the stream.</param>
         /// <param name="sourceImage">The image that the stream shiuld contain.</param>
         /// <param name="generation">The object generation number (usually 0).</param>
-        public PdfJpegImageStream(int objectId, JpegSourceImage sourceImage, int generation = 0) : base(objectId, GetJpegFilterEncoders(), generation)
+        public PdfJpegImageStream(int objectId, JpegSourceImage sourceImage, int generation = 0) : 
+            base(objectId, GetJpegFilterEncoders(sourceImage.EncodingMode), generation)
         {
             if (sourceImage is null)
             {
@@ -37,10 +38,10 @@ namespace Unicorn.Writer.Streams
             InternalContents.AddRange(sourceImage.RawData);
         }
 
-        private static IEnumerable<IPdfFilterEncoder> GetJpegFilterEncoders()
+        private static IEnumerable<IPdfFilterEncoder> GetJpegFilterEncoders(JpegEncodingMode encodingMode)
         {
             var encoders = new List<IPdfFilterEncoder>() { JpegFakeEncoder.Instance };
-            if (Features.SelectedStreamFeatures.HasFlag(Features.StreamFeatures.AsciiEncodeBinaryStreams))
+            if (encodingMode != JpegEncodingMode.Progressive && Features.SelectedStreamFeatures.HasFlag(Features.StreamFeatures.AsciiEncodeBinaryStreams))
             {
                 encoders.Add(Ascii85Encoder.Instance);
             }

--- a/src/Unicorn/Writer/Streams/PdfJpegImageStream.cs
+++ b/src/Unicorn/Writer/Streams/PdfJpegImageStream.cs
@@ -25,7 +25,7 @@ namespace Unicorn.Writer.Streams
         /// <param name="sourceImage">The image that the stream shiuld contain.</param>
         /// <param name="generation">The object generation number (usually 0).</param>
         public PdfJpegImageStream(int objectId, JpegSourceImage sourceImage, int generation = 0) : 
-            base(objectId, GetJpegFilterEncoders(sourceImage.EncodingMode), generation)
+            base(objectId, GetJpegFilterEncoders(sourceImage?.EncodingMode), generation)
         {
             if (sourceImage is null)
             {
@@ -38,7 +38,7 @@ namespace Unicorn.Writer.Streams
             InternalContents.AddRange(sourceImage.RawData);
         }
 
-        private static IEnumerable<IPdfFilterEncoder> GetJpegFilterEncoders(JpegEncodingMode encodingMode)
+        private static IEnumerable<IPdfFilterEncoder> GetJpegFilterEncoders(JpegEncodingMode? encodingMode)
         {
             var encoders = new List<IPdfFilterEncoder>() { JpegFakeEncoder.Instance };
             if (encodingMode != JpegEncodingMode.Progressive && Features.SelectedStreamFeatures.HasFlag(Features.StreamFeatures.AsciiEncodeBinaryStreams))


### PR DESCRIPTION
According to the PDF documentation, progressive JPEG files must be embedded as-is and cannot use any other sort of stream filter.

Default Unicorn behaviour was to ASCII-encode all binary streams.  This turns that off for all JPEG streams whose Start Of Frame marker indicates that they are progressively encoded.